### PR TITLE
fixed several cargo clippy warnings (~ micro code cleanup)

### DIFF
--- a/src/scad_element.rs
+++ b/src/scad_element.rs
@@ -124,7 +124,7 @@ impl PolygonParameters
     pub fn new(points: Vec<na::Vector2<f32>>) -> PolygonParameters
     {
         PolygonParameters {
-            points: points,
+            points,
             path: PolygonPathType::Default,
             convexity: 10
         }

--- a/src/scad_file.rs
+++ b/src/scad_file.rs
@@ -90,19 +90,20 @@ impl ScadFile
             Ok(file) => file,
         };
 
-        match file.write(self.get_code().as_bytes()) {
-            Err(_) => 
-                {
-                    println!("Failed to write to output file");
-                    return false;
-                },
-            Ok(_) => {}
+        if file.write(self.get_code().as_bytes()).is_err() {
+            println!("Failed to write to output file");
+            return false;
         };
 
-        return true;
+        true
     }
 }
 
+impl Default for ScadFile {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 
 #[cfg(test)]

--- a/src/scad_object.rs
+++ b/src/scad_object.rs
@@ -51,7 +51,7 @@ impl ScadObject
     pub fn new(element: ScadElement) -> ScadObject 
     {
         ScadObject {
-            element: element,
+            element,
 
             children: Vec::new(),
 
@@ -94,7 +94,7 @@ impl ScadObject
                     {
                         //Add the children indented one line
                         child_code = child_code + "\t" + &(stmt.get_code().replace("\n", "\n\t"));
-                        child_code = child_code + "\n";
+                        child_code += "\n";
                     }
 
                     //Add the final bracket and 'return' the result
@@ -102,7 +102,7 @@ impl ScadObject
                 }
         });
 
-        return result;
+        result
     }
 
     /**

--- a/src/scad_type.rs
+++ b/src/scad_type.rs
@@ -71,7 +71,7 @@ impl<T: ScadType> ScadType for Vec<T>
             result = result + &elem.get_code() + ",";
         }
         
-        result = result + "]";
+        result += "]";
 
         result
     }


### PR DESCRIPTION
resolved warnings reported for Rust v. 1.48.0