### PR TITLE
draft implementation of include statement and FunctionCall ScadObject

### DIFF
--- a/src/scad_file.rs
+++ b/src/scad_file.rs
@@ -14,6 +14,11 @@ pub struct ScadFile
 {
     objects: Vec<ScadObject>,
 
+    /// List of .scad scripts to be included.
+    /// Current implementation does not allow to use include statement anywhere in file as it should.
+    /// (for own variable pre-setting)
+    includes: Vec<String>,
+
     detail: i32,
 }
 
@@ -23,6 +28,8 @@ impl ScadFile
     {
         ScadFile {
             objects: Vec::new(),
+
+            includes: Vec::new(),
 
             detail: 0,
         }
@@ -41,12 +48,22 @@ impl ScadFile
             result = result + "$fn=" + &self.detail.to_string() + ";\n";
         }
 
+        for include in &self.includes
+        {
+            result = result + &format!("include <{}>", include) + "\n";
+        }
+
         for object in &self.objects
         {
             result = result + &object.get_code() + "\n";
         }
 
         result
+    }
+
+    pub fn add_include(&mut self, include: String)
+    {
+        self.includes.push(include);
     }
 
     pub fn add_object(&mut self, object: ScadObject) 

--- a/src/scad_type.rs
+++ b/src/scad_type.rs
@@ -24,6 +24,14 @@ impl ScadType for na::Vector2<f32>
     }
 }
 
+impl ScadType for na::Vector1<f32>
+{
+    fn get_code(&self) -> String
+    {
+        String::from("[") + &self.x.get_code() + "]"
+    }
+}
+
 impl ScadType for f32
 {
     fn get_code(&self) -> String 


### PR DESCRIPTION
I tried to quickly look into `docs`, but the amount felt a bit scary... :) thus no committed usage example.
Adding code snippet here, to get a feel on how to use this:


```rust
    // add include statement to the top of resulting OpenSCAD file:
    let mut scad_file = ScadFile::new();
    scad_file.add_include("SomeCustom.scad".to_string());

    // and someplace where building ScadObjects:
    let fn_name = "SomeScadFunction".to_string();

    // can add items of different types into arguments vector
    let fn_args: FnCallArgs = vec![Box::new(vec2(3.0, 4.0)), Box::new(1.0)];

    // can add items of different types into named arguments vector as well
    let fn_named_args: FnCallNamedArgs = vec![
        ("resolution".to_string(), Box::new(123)),
        ("centered".to_string(), Box::new(false)),
    ];

    let scad_object = scad!(FunctionCall(
        fn_name,
        Some(Rc::new(fn_args)),
        Some(Rc::new(fn_named_args))
    ));

    scad_file.add_object(scad_object);
```


results in following code neing generated:

```openscad
    include <SomeCustom.scad>
    SomeScadFunction([3,4], 1, resolution = 123, centered = false);
```



